### PR TITLE
Support running externally defined statistics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -408,6 +408,19 @@ Will output filenames similar to:
 
     10_15/LS_PQ_COUNT_3577_10_15_2010-01-01_2011-01-01.nc
 
+
+Product type
+~~~~~~~~~~~~
+
+Optional field allows to specify `product_type` field of the output product.
+Defaults to `!!NOTSET!!`. This is needed when output is to be indexed into the
+data cube.
+
+.. code-block:: yaml
+
+        product_type: seasonal_stats
+
+
 Complete example
 ~~~~~~~~~~~~~~~~
 
@@ -415,6 +428,7 @@ Complete example
 
     output_products:
      - name: landsat_seasonal_mean
+       product_type: seasonal_stats
        statistic: mean
        output_params:
          zlib: True
@@ -422,6 +436,7 @@ Complete example
        file_path_template: 'SR_N_MEAN/SR_N_MEAN_3577_{x:02d}_{y:02d}_{epoch_start:%Y%m%d}.nc'
 
      - name: landsat_seasonal_medoid
+       product_type: seasonal_stats
        statistic: medoid
        output_params:
          zlib: True
@@ -429,6 +444,7 @@ Complete example
        file_path_template: 'SR_N_MEDOID/SR_N_MEDOID_3577_{x:02d}_{y:02d}_{epoch_start:%Y%m%d}.nc'
 
      - name: landsat_seasonal_percentile_10
+       product_type: seasonal_stats
        statistic: percentile_10
        statistic_args:
          q: 10

--- a/README.rst
+++ b/README.rst
@@ -360,8 +360,8 @@ Define the name of the output product. eg:
 Product type
 ~~~~~~~~~~~~
 
-Optional field allows to specify `product_type`_ field of the output product.
-Defaults to `!!NOTSET!!`_. This is needed when output is to be indexed into the
+Optional field allows to specify ``product_type`` field of the output product.
+Defaults to ``!!NOTSET!!``. This is needed when output is to be indexed into the
 data cube.
 
 .. code-block:: yaml

--- a/README.rst
+++ b/README.rst
@@ -357,6 +357,18 @@ Define the name of the output product. eg:
 
     name: landsat_yearly_mean
 
+Product type
+~~~~~~~~~~~~
+
+Optional field allows to specify `product_type`_ field of the output product.
+Defaults to `!!NOTSET!!`_. This is needed when output is to be indexed into the
+data cube.
+
+.. code-block:: yaml
+
+        product_type: seasonal_stats
+
+
 Statistic/calculation
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -408,17 +420,6 @@ Will output filenames similar to:
 
     10_15/LS_PQ_COUNT_3577_10_15_2010-01-01_2011-01-01.nc
 
-
-Product type
-~~~~~~~~~~~~
-
-Optional field allows to specify `product_type` field of the output product.
-Defaults to `!!NOTSET!!`. This is needed when output is to be indexed into the
-data cube.
-
-.. code-block:: yaml
-
-        product_type: seasonal_stats
 
 
 Complete example

--- a/datacube_stats/models.py
+++ b/datacube_stats/models.py
@@ -65,7 +65,7 @@ class OutputProduct(object):
       - Input measurements
     """
 
-    def __init__(self, metadata_type, input_measurements, storage, name, file_path_template,
+    def __init__(self, metadata_type, product_type, input_measurements, storage, name, file_path_template,
                  stat_name, statistic, output_params=None, extras=None):
         #: The product name.
         self.name = name
@@ -81,7 +81,7 @@ class OutputProduct(object):
 
         self.data_measurements = statistic.measurements(input_measurements)
 
-        self.product = self._create_product(metadata_type, self.data_measurements, storage)
+        self.product = self._create_product(metadata_type, product_type, self.data_measurements, storage)
         self.output_params = output_params
 
         #: A dictionary of extra arguments to be used through the processing chain
@@ -90,7 +90,9 @@ class OutputProduct(object):
 
     @classmethod
     def from_json_definition(cls, metadata_type, input_measurements, storage, definition):
-        return cls(metadata_type, input_measurements, storage,
+        return cls(metadata_type,
+                   definition.get('product_type', '!!NOTSET!!'),
+                   input_measurements, storage,
                    name=definition['name'],
                    file_path_template=definition.get('file_path_template'),
                    stat_name=definition['statistic'],
@@ -101,14 +103,14 @@ class OutputProduct(object):
     def compute(self):
         return self.statistic.compute
 
-    def _create_product(self, metadata_type, data_measurements, storage):
+    def _create_product(self, metadata_type, product_type, data_measurements, storage):
         product_definition = {
             'name': self.name,
             'description': 'Description for ' + self.name,
             'metadata_type': 'eo',
             'metadata': {
                 'format': 'NetCDF',
-                'product_type': self.stat_name,
+                'product_type': product_type,
             },
             'storage': storage,
             'measurements': data_measurements

--- a/datacube_stats/models.py
+++ b/datacube_stats/models.py
@@ -109,7 +109,9 @@ class OutputProduct(object):
             'description': 'Description for ' + self.name,
             'metadata_type': 'eo',
             'metadata': {
-                'format': 'NetCDF',
+                'format': {
+                    'name': 'NetCDF'
+                },
                 'product_type': product_type,
             },
             'storage': storage,

--- a/datacube_stats/statistics.py
+++ b/datacube_stats/statistics.py
@@ -686,6 +686,28 @@ class MaskedCount(Statistic):
                  'nodata': 65536}]  # No Data is required somewhere, but doesn't really make sense
 
 
+class ExternalPlugin(Statistic):
+    """
+    Run externally defined plugin.
+
+    """
+    def __init__(self, impl, *args, **kwargs):
+        from pydoc import locate  # TODO: probably should use importlib, but this works so easily
+
+        impl_class = locate(impl)
+
+        if impl_class is None:
+            raise StatsProcessingError("Failed to load external plugin: '{}'".format(impl))
+
+        self._impl = impl_class(*args, **kwargs)
+
+    def compute(self, data):
+        return self._impl.compute(data)
+
+    def measurements(self, input_measurements):
+        return self._impl.measurements(input_measurements)
+
+
 STATS = {
     'simple': ReducingXarrayStatistic,
     # 'min': SimpleXarrayReduction('min'),
@@ -707,6 +729,7 @@ STATS = {
     'clear_count': ClearCount,
     'masked_count': MaskedCount,
     'flag_counter': FlagCounter,
+    'external': ExternalPlugin,
 }
 
 


### PR DESCRIPTION
Adding class `ExternalPlugin` accessible via `external` name in the config. This
class is a proxy for running statistic computations defined outside of the
`datacube_stats` module.

Example config:

``` yaml
output_products:
 - name: very_custom_stats
   statistic: external
   statistic_args:
     impl: uu.stats.VeryCustom # custom class defined anywhere on PYTHONPATH
     custom_flag: 1 # All other args are passed to the custom plugin
     more_args: [3,4]
     some_more:
       - a
       - b   
```

Also adding `product_type` field