### PR TITLE
PBS work pool launcher

### DIFF
--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -100,7 +100,9 @@ def list_statistics(ctx, param, value):
 @click.option('--version', is_flag=True, callback=_print_version,
               expose_value=False, is_eager=True)
 @ui.pass_index(app_name='datacube-stats')
-def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks, tile_index, output_location, year, pbs_celery):
+def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks,
+         tile_index, output_location, year,
+         pbs_celery):
     _log_setup()
 
     timer = MultiTimer().start('main')

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -94,12 +94,13 @@ def list_statistics(ctx, param, value):
 @click.option('--output-location', help='Override output location in configuration file')
 @click.option('--year', type=int, help='Override time period in configuration file')
 @click.option('--list-statistics', is_flag=True, callback=list_statistics, expose_value=False)
+@click.option('--pbs-celery', is_flag=True, help='Launch worker pool when running on PBS')
 @ui.global_cli_options
 @ui.executor_cli_options
 @click.option('--version', is_flag=True, callback=_print_version,
               expose_value=False, is_eager=True)
 @ui.pass_index(app_name='datacube-stats')
-def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks, tile_index, output_location, year):
+def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks, tile_index, output_location, year, pbs_celery):
     _log_setup()
 
     timer = MultiTimer().start('main')
@@ -109,6 +110,16 @@ def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks,
     app.queue_size = queue_size
     app.validate()
 
+    shutdown = None
+
+    if pbs_celery:
+        from .utils import pbs
+        click.echo('Launching Redis worker pool')
+        try:
+            executor, shutdown = pbs.launch_redis_worker_pool()
+        except RuntimeError:
+            raise click.ClickException('Failed to launch redis worker pool')
+
     if save_tasks:
         app.save_tasks_to_file(save_tasks)
         failed = 0
@@ -116,6 +127,10 @@ def main(index, stats_config_file, executor, queue_size, save_tasks, load_tasks,
         successful, failed = app.run(executor, load_tasks)
     else:
         successful, failed = app.run(executor)
+
+    if shutdown is not None:
+        click.echo('Calling shutdown hook')
+        shutdown()
 
     timer.pause('main')
     _LOG.info('Stats processing completed in %s seconds.', timer.run_times['main'])

--- a/datacube_stats/utils/pbs.py
+++ b/datacube_stats/utils/pbs.py
@@ -1,0 +1,135 @@
+from collections import namedtuple, OrderedDict
+Node = namedtuple('Node','name num_cores offset is_main'.split(' '))
+
+_nodes = None
+
+def _hostname():
+    import os
+    return os.environ.get('HOSTNAME', os.environ.get('HOST', 'localhost'))
+
+def is_under_pbs():
+    import os
+    return 'PBS_NODEFILE' in os.environ
+
+def parse_nodes_file(fname=None):
+    import os
+
+    if fname is None:
+        fname = os.environ.get('PBS_NODEFILE')
+        if fname is None:
+            raise RuntimeError("Can't find PBS node file")
+
+    def load_lines(fname):
+        with open(fname,'r') as f:
+            ll = [l.strip() for l in f.readlines()]
+            return [l for l in ll if len(l) > 0]
+
+    hostname = _hostname()
+    nodes = OrderedDict()
+
+    for idx, l in enumerate(load_lines(fname)):
+        if l in nodes:
+            nodes[l]['num_cores'] += 1
+        else:
+            nodes[l] = dict(name=l, num_cores=1, offset=idx, is_main=(hostname == l))
+
+    return [Node(**x) for x in nodes.values()]
+
+def nodes():
+    global _nodes
+    if _nodes is None:
+        _nodes = parse_nodes_file()
+    return _nodes
+
+def get_env(extras=[], **more_env):
+    import os
+    import re
+
+    pass_envs=set(['PATH','LANG','LD_LIBRARY_PATH','HOME','USER'])
+    REGEXES=['^PYTHON.*', '^GDAL.*', '^LC.*']
+    rgxs=[re.compile(r) for r in REGEXES]
+
+    def need_this_env(k):
+        if k in pass_envs or k in extras:
+            return True
+        for rgx in rgxs:
+            if rgx.match(k):
+                return True
+        return False
+
+    ee = dict( (k,v) for k,v in os.environ.items() if need_this_env(k) )
+    ee.update(**more_env)
+    return ee
+
+def mk_exports(env):
+    return '\n'.join('export {}="{}"'.format(k,v) for k,v in env.items())
+
+def generate_env_header(extras=[], **more_env):
+    return mk_exports( get_env(extras, **more_env) )
+
+def wrap_script(script):
+    from base64 import b64encode
+    b64s = b64encode(script.encode('ascii')).decode('ascii')
+    return 'eval "$(echo {}|base64 -d)"'.format(b64s)
+
+
+def pbsdsh(cpu_num, script, env=None, test_mode=False):
+    import subprocess
+
+    if env is None:
+        env = get_env()
+
+    hdr = mk_exports(env) + '\n\n'
+
+    if test_mode:
+        args = "env -i bash --norc -c".split(' ')
+    else:
+        args = "pbsdsh -n {} -- bash -c".format(cpu_num).split(' ')
+
+    args.append( wrap_script(hdr + script) )
+    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def launch_redis_worker_pool(port=6379):
+    import os
+    from time import sleep
+    from datacube import _celery_runner as cr
+
+    redis_port = port
+    redis_host = _hostname()
+    redis_password = cr.get_redis_password(generate_if_missing=True)
+
+    redis_shutdown = cr.launch_redis(redis_port, redis_password)
+
+    if not redis_shutdown:
+        raise RuntimeError('Failed to launch Redis')
+
+    for i in range(5):
+        if cr.check_redis(redis_host, redis_port, redis_password) is False:
+            sleep(0.5)
+
+    executor = cr.CeleryExecutor(redis_host, redis_port, password=redis_password)
+
+    worker_env = get_env()
+    worker_procs = []
+
+    for node in nodes():
+        nprocs = node.num_cores
+        if node.is_main:
+            nprocs = max(1, nprocs - 2)
+
+        celery_worker_script='exec datacube-worker --executor celery {}:{} --nprocs {} >/dev/null 2>/dev/null'.format(redis_host, redis_port, nprocs)
+        proc = pbsdsh(node.offset, celery_worker_script, env=worker_env)
+        worker_procs.append(proc)
+
+
+    def shutdown():
+        cr.app.control.shutdown()
+        redis_shutdown()
+
+        # TODO: time limit followed by kill
+        for p in worker_procs:
+            p.wait()
+
+
+    return executor, shutdown

--- a/datacube_stats/utils/pbs.py
+++ b/datacube_stats/utils/pbs.py
@@ -1,15 +1,18 @@
 from collections import namedtuple, OrderedDict
-Node = namedtuple('Node','name num_cores offset is_main'.split(' '))
+Node = namedtuple('Node', 'name num_cores offset is_main'.split(' '))
 
 _nodes = None
+
 
 def _hostname():
     import os
     return os.environ.get('HOSTNAME', os.environ.get('HOST', 'localhost'))
 
+
 def is_under_pbs():
     import os
     return 'PBS_NODEFILE' in os.environ
+
 
 def parse_nodes_file(fname=None):
     import os
@@ -20,7 +23,7 @@ def parse_nodes_file(fname=None):
             raise RuntimeError("Can't find PBS node file")
 
     def load_lines(fname):
-        with open(fname,'r') as f:
+        with open(fname, 'r') as f:
             ll = [l.strip() for l in f.readlines()]
             return [l for l in ll if len(l) > 0]
 
@@ -31,9 +34,15 @@ def parse_nodes_file(fname=None):
         if l in nodes:
             nodes[l]['num_cores'] += 1
         else:
-            nodes[l] = dict(name=l, num_cores=1, offset=idx, is_main=(hostname == l))
+            nodes[l] = dict(
+                name=l,
+                num_cores=1,
+                offset=idx,
+                is_main=(
+                    hostname == l))
 
     return [Node(**x) for x in nodes.values()]
+
 
 def nodes():
     global _nodes
@@ -41,13 +50,14 @@ def nodes():
         _nodes = parse_nodes_file()
     return _nodes
 
+
 def get_env(extras=[], **more_env):
     import os
     import re
 
-    pass_envs=set(['PATH','LANG','LD_LIBRARY_PATH','HOME','USER'])
-    REGEXES=['^PYTHON.*', '^GDAL.*', '^LC.*']
-    rgxs=[re.compile(r) for r in REGEXES]
+    pass_envs = set(['PATH', 'LANG', 'LD_LIBRARY_PATH', 'HOME', 'USER'])
+    REGEXES = ['^PYTHON.*', '^GDAL.*', '^LC.*']
+    rgxs = [re.compile(r) for r in REGEXES]
 
     def need_this_env(k):
         if k in pass_envs or k in extras:
@@ -57,15 +67,18 @@ def get_env(extras=[], **more_env):
                 return True
         return False
 
-    ee = dict( (k,v) for k,v in os.environ.items() if need_this_env(k) )
+    ee = dict((k, v) for k, v in os.environ.items() if need_this_env(k))
     ee.update(**more_env)
     return ee
 
+
 def mk_exports(env):
-    return '\n'.join('export {}="{}"'.format(k,v) for k,v in env.items())
+    return '\n'.join('export {}="{}"'.format(k, v) for k, v in env.items())
+
 
 def generate_env_header(extras=[], **more_env):
-    return mk_exports( get_env(extras, **more_env) )
+    return mk_exports(get_env(extras, **more_env))
+
 
 def wrap_script(script):
     from base64 import b64encode
@@ -86,12 +99,14 @@ def pbsdsh(cpu_num, script, env=None, test_mode=False):
     else:
         args = "pbsdsh -n {} -- bash -c".format(cpu_num).split(' ')
 
-    args.append( wrap_script(hdr + script) )
-    return subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    args.append(wrap_script(hdr + script))
+    return subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
 
 
 def launch_redis_worker_pool(port=6379):
-    import os
     from time import sleep
     from datacube import _celery_runner as cr
 
@@ -108,7 +123,10 @@ def launch_redis_worker_pool(port=6379):
         if cr.check_redis(redis_host, redis_port, redis_password) is False:
             sleep(0.5)
 
-    executor = cr.CeleryExecutor(redis_host, redis_port, password=redis_password)
+    executor = cr.CeleryExecutor(
+        redis_host,
+        redis_port,
+        password=redis_password)
 
     worker_env = get_env()
     worker_procs = []
@@ -118,10 +136,10 @@ def launch_redis_worker_pool(port=6379):
         if node.is_main:
             nprocs = max(1, nprocs - 2)
 
-        celery_worker_script='exec datacube-worker --executor celery {}:{} --nprocs {} >/dev/null 2>/dev/null'.format(redis_host, redis_port, nprocs)
+        celery_worker_script = 'exec datacube-worker --executor celery {}:{} --nprocs {} >/dev/null 2>/dev/null'.format(
+            redis_host, redis_port, nprocs)
         proc = pbsdsh(node.offset, celery_worker_script, env=worker_env)
         worker_procs.append(proc)
-
 
     def shutdown():
         cr.app.control.shutdown()
@@ -130,6 +148,5 @@ def launch_redis_worker_pool(port=6379):
         # TODO: time limit followed by kill
         for p in worker_procs:
             p.wait()
-
 
     return executor, shutdown


### PR DESCRIPTION
This adds `--pbs-celery` meant to replace launch scripts.

This option only works when running inside a PBS job, when supplied `datacube-stats` will launch redis server and if successful launch worker nodes, one per allocated cpu except for the first 2 cpus which are reserved for task generation and redis server. It will always launch at least one worker, even if only one cpu was allocated.

Example qsub launcher script

```
#!/bin/bash

#PBS -P u46
#PBS -q normal
#PBS -l walltime=01:00:00
#PBS -l mem=63GB
#PBS -l ncpus=32

set -e

cd ${PBS_O_WORKDIR}
ENV=$(pwd)/env.sh
source $ENV

exec datacube-stats --pbs-celery \
     --queue-size 64 \
     --year 2015 \
     --output-location '/g/data/u46/users/kk7182/PQ2/' \
     pq_count_albers.yaml
```

User experience part needs further work:

1. Should not need to specify `--queue-size`
2. Should be able to pass itself into `qsub` (possibly after task list generation)

From code UX perspective also needs more work

1. Too much code in `main`
2. Need to rethink `executor` `@click` options
