### PR TITLE
Allow setting per variable attributes from config

### DIFF
--- a/configurations/pq/pq_count_albers.yaml
+++ b/configurations/pq/pq_count_albers.yaml
@@ -24,24 +24,57 @@ sources:
 
 global_attributes:
   title: Pixel Quality Statistics 25 v2
-  description: Count of clear surface observations 25 metre, 100km tile, Australian Albers Equal Area projection (EPSG:3577)
-  summary: TODO
+
+  summary: >
+    PQ25 Count is an aggregate assessment of a collection of image
+    pixels to determine if they are unobscured, unsaturated observations of the
+    Earth's surface and whether the pixels are represented in each spectral
+    band.
+
   institution: Commonwealth of Australia (Geoscience Australia)
   keywords_vocabulary: GCMD
   keywords: AU/GA,NASA/GSFC/SED/ESD/LANDSAT,ETM+,TM,OLI,EARTH SCIENCE
   platform: LANDSAT-5,LANDSAT-7,LANDSAT-8
   instrument: TM,ETM+,OLI
+
+  publisher_type: institution
   publisher_email: earth.observation@ga.gov.au
   publisher_name: Section Leader, Operations Section, NEMO, Geoscience Australia
   publisher_url: http://www.ga.gov.au
+
   license: CC BY Attribution 4.0 International License
   cdm_data_type: Grid
   product_version: 2
   product_suite: Pixel Quality 25m
   acknowledgment: Landsat data is provided by the United States Geological Survey (USGS) through direct reception of the data at Geoscience Australias satellite reception facility or download.
-  coverage_content_type: physicalMeasurement
   cdm_data_type: Grid
   product_suite: Clear Observation Count - 25
+  source: Remotely observed surface reflectance and modelled cloud/shadow
+  references: |
+    - Berk, A., Anderson, G.P., Acharya, P.K., Hoke, M.L., Chetwynd, J.H., Bernstein, L.S., Shettle, E.P., Matthew, M.W., and Adler-Golden, S.M. (2003) Modtran 4 Version 3 Revision 1 User s manual. Airforce Research Laboratory, Hanscom, MA, USA.
+    - Chander, G., Markham, B.L., and Helder, D.L. (2009) Summary of current radiometric calibration coefficients for Landsat MSS, TM, ETM+, and EO-1 ALI sensors. Remote Sensing of Environment 113, 893-903.
+    - Edberg, R., and Oliver, S. (2013) Projection-Independent Earth-Solar-Sensor Geometry for Surface Reflectance Correction. Submitted to IGARSS 2013, Melbourne.
+    - Forrest, R.B. (1981) Simulation of orbital image-sensor geometry, Photogrammetric Engineering and Remote Sensing 47, 1187-93.
+    - GA and CSIRO (2010) 1 second SRTM Derived Digital Elevation Models User Guide. Version 1.03. GA, Canberra.
+    - Irish, R. (2000) Landsat 7 Automatic Cloud Cover Assessment, sourced: http://landsathandbook.gsfc.nasa.gov/pdfs/ACCA_SPIE_paper.pdf, last accessed 12/11/2012.
+    - Irons, J.R., Dwyer, J.L., and Barsi, J.A. (2012) The next Landsat satellite: The Landsat Data Continuity Mission. Remote Sensing of Environment (2012), doi:10.1016/j.rse.2011.08.026
+    - Kalnay, E. Kanamitsu, M., Kistler, R., Collins, W., Deaven, D., Gandin, L., Iredell, M., Saha, S., White, G., Woollen, J., Zhu, Y., Chelliah, M., Ebisuzaki, W., Higgins, W., Janowiak, J., Mo, K.C., Ropelewski, C., Wang, J., Leetmaa, A., Reynolds, R. Jenne, R., Joseph, D. (1996) The NCEP/NCAR 40-Year Reanalysis Project. Bulletin of the American Meteorological Society 77, 437-71.
+    - Li, F., Jupp, D.L.B., Reddy, S., Lymburner, L., Mueller, N., Tan, P., and Islam, A. (2010) An Evaluation of the Use of Atmospheric and BRDF Correction to Standardize Landsat Data. IEEE J. Selected Topics in Applied Earth Observations and Remote Sensing 3, 257-70.;Li, F. (2010) ARG25 Algorithm Theoretical Basis Document. GA, Canberra.
+    - Li, F., Jupp, D.L.B., Thankappan, M., Lymburner, L., Mueller, N., Lewis, A., and Held, A. (2012) A physics-based atmopheric and BRDF correction for Landsat data over mountainous terrain. Remote Sensing of Environment 124, 756-70.
+    - Lubke, M. (2012) Landsat Geometry Calibration/Validation Update. Presentation at LTWG #21, 25 September 2012, Sioux Falls. USGS, USA.
+    - OGC (2006) OpenGIS Web Map Server Implementation Specification (Ed: Jeff de la Beaujardiere) Ref. OGC 06-042.
+    - OGC (2010) OGC WCS 2.0 Interface Standard - Core. (Ed: Peter Baumann) Ref. OGC 09-110r3.
+    - OGC (2013) CF-netCDF3 Data Model Extension Standard (Eds: Ben Domenico and Stefano Nativi) Ref. OGC 11-165r2.
+    - Roy, D.P., Ju, J., Kline, K., Scaramuzza, P.L., Kovalskyy, V., Hansen, M., Loveland, T.R., Vermote, E., & Zhang, C. (2010). Web-enabled Landsat Data (WELD): Landsat ETM+ composited mosaics of the conterminous United States. Remote Sensing of Environment, 114, 35-49.
+    - Sixsmith, J., Oliver, S., & Lymburner, L. (2013). A hybrid approach to automated Landsat pixel quality. In, Geoscience and Remote Sensing Symposium (IGARSS), 2013 IEEE International (pp. 4146-4149).
+    - Strahler, A.H., and Muller, J.-P. (1999) MODIS BRDF/Albedo Product: Algorithm Theoretical Basis Document Version 5.0. http://modis.gsfc.nasa.gov/data/atbd/atbd_mod09.pdf
+    - TM World Borders vector file: http://thematicmapping.org/downloads/world_borders.php
+    - USGS (2012a) Landsat Thematic Mapper (TM) Level 1 (L1) Data Format Control Book (DFCB). LS-DFCB-20 Version 4.0. USGS, USA. http://landsat.usgs.gov/documents/LS-DFCB-20.pdf
+    - USGS (2012b) Landsat 7 ETM+ Level 1 Product Data Format Control Book (DFCB). LS-DFCB-04 Version 15.0.  http://landsat.usgs.gov/documents/LS-DFCB-04.pdf
+    - Vincenty, T. (1975) Direct and Inverse Solutions of Geodesies on the Ellipsoid with Application of Nested Equations. Survey Review 23, 88-93.
+    - Zhu, Z. and Woodcock, C. E. (2012) Object-based cloud and cloud shadow detection in Landsat imagery. Remote Sensing of Environment 118, 83-94.
+    - http://dx.doi.org/10.4225/25/55EF55788BAC1
+
 
 storage:
   driver: NetCDFCF
@@ -108,4 +141,3 @@ computation:
   chunking:
     x: 1000
     y: 1000
-

--- a/configurations/pq/pq_count_albers.yaml
+++ b/configurations/pq/pq_count_albers.yaml
@@ -100,12 +100,12 @@ date_ranges:
   stats_duration: 12m
   step_size: 12m
 
-#location: '/g/data/u46/users/kk7182/PQ2/'
+location: '/g/data/u46/users/kk7182/PQ/'
 
 ## Computational
 # Decide based on how much can fit into memory on the node that is running the job.
 computation:
   chunking:
-    x: 2000
-    y: 2000
+    x: 1000
+    y: 1000
 

--- a/configurations/pq/pq_count_albers.yaml
+++ b/configurations/pq/pq_count_albers.yaml
@@ -75,6 +75,14 @@ global_attributes:
     - Zhu, Z. and Woodcock, C. E. (2012) Object-based cloud and cloud shadow detection in Landsat imagery. Remote Sensing of Environment 118, 83-94.
     - http://dx.doi.org/10.4225/25/55EF55788BAC1
 
+var_attributes:
+  clear_observation_count:
+    long_name: Number of clear observations for a pixel in a time period
+    coverage_content_type: qualityInformation
+  total_observation_count:
+    long_name: Total observations for a pixel in a time period
+    coverage_content_type: qualityInformation
+
 
 storage:
   driver: NetCDFCF

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -248,7 +248,8 @@ class StatsApp(object):
                                 output_path=self.location,
                                 app_info=app_info,
                                 storage=self.storage,
-                                global_attributes=self.global_attributes)
+                                global_attributes=self.global_attributes,
+                                var_attributes=self.var_attributes)
         task_runner = partial(execute_task,
                               output_driver=output_driver,
                               chunking=self.computation.get('chunking', {}))
@@ -538,6 +539,7 @@ def create_stats_app(config, index=None, tile_index=None, output_location=None, 
     stats_app.task_generator = _select_task_generator(input_region, stats_app.storage)
     stats_app.output_driver = _prepare_output_driver(stats_app.storage)
     stats_app.global_attributes = config.get('global_attributes', {})
+    stats_app.var_attributes = config.get('var_attributes', {})
     stats_app.process_completed = do_nothing  # TODO: Save dataset to database
 
     return stats_app

--- a/datacube_stats/output_drivers.py
+++ b/datacube_stats/output_drivers.py
@@ -10,6 +10,7 @@ import logging
 import operator
 import subprocess
 import tempfile
+import pydash
 from collections import OrderedDict
 from functools import reduce as reduce_
 from pathlib import Path
@@ -110,7 +111,7 @@ class OutputDriver(with_metaclass(RegisterDriver)):
     """
     valid_extensions = []
 
-    def __init__(self, task, storage, output_path, app_info=None, global_attributes=None):
+    def __init__(self, task, storage, output_path, app_info=None, global_attributes=None, var_attributes=None):
         self._storage = storage
 
         self._output_path = output_path
@@ -131,6 +132,9 @@ class OutputDriver(with_metaclass(RegisterDriver)):
 
         #: dict of str to str
         self.global_attributes = global_attributes
+
+        #: dict of str to dict of str to str
+        self.var_attributes = var_attributes if var_attributes is not None else {}
 
     def close_files(self, completed_successfully):
         # Turn file_handles into paths
@@ -179,7 +183,7 @@ class OutputDriver(with_metaclass(RegisterDriver)):
         make sure it is valid and doesn't already exist
         Make sure parent directories exist
         Switch it around for a temporary filename.
-        
+
         :return: Path to write output to
         """
         output_path = self._generate_output_filename(output_product, **kwargs)
@@ -227,7 +231,7 @@ class OutputDriver(with_metaclass(RegisterDriver)):
         :return: (datasets, sources)
         datasets is a bunch of strings to dump, indexed on time
         sources is a more structured form. An x-array of lists of dataset sources, indexed on time
-        
+
 
         """
         task = self._task
@@ -305,6 +309,13 @@ class NetCDFCFOutputDriver(OutputDriver):
         return nco
 
     def _create_netcdf_var_params(self, stat):
+        def build_attrs(var):
+            name = var['name']
+            return pydash.assign(dict(long_name=name,
+                                      coverage_content_type='modelResult'),  # defaults
+                                 var.get('attrs', {}),                       # Defined by plugin
+                                 self.var_attributes.get(name, {}))          # <- From config, highest priority
+
         chunking = self._storage['chunking']
         chunking = [chunking[dim] for dim in self._storage['dimension_order']]
 
@@ -313,11 +324,13 @@ class NetCDFCFOutputDriver(OutputDriver):
             name = measurement['name']
             variable_params[name] = stat.output_params.copy()
             variable_params[name]['chunksizes'] = chunking
+            variable_params[name]['attrs'] = build_attrs(measurement)
             variable_params[name].update(
                 {k: v for k, v in measurement.items() if k in _NETCDF_VARIABLE__PARAMETER_NAMES})
         return variable_params
 
     def _nco_from_sources(self, sources, geobox, measurements, variable_params, filename):
+
         coordinates = OrderedDict((name, geometry.Coordinate(coord.values, coord.units))
                                   for name, coord in sources.coords.items())
         coordinates.update(geobox.coordinates)
@@ -451,9 +464,9 @@ class GeotiffOutputDriver(OutputDriver):
         dtype = self._get_dtype(prod_name, measurement_name)
         nodata = self._get_nodata(prod_name, measurement_name)
         x_block_size = self._storage['chunking']['x'] if 'x' in self._storage['chunking'] else \
-        self._storage['chunking']['longitude']
+            self._storage['chunking']['longitude']
         y_block_size = self._storage['chunking']['y'] if 'y' in self._storage['chunking'] else \
-        self._storage['chunking']['latitude']
+            self._storage['chunking']['latitude']
         profile.update({
             'blockxsize': x_block_size,
             'blockysize': y_block_size,

--- a/datacube_stats/statistics.py
+++ b/datacube_stats/statistics.py
@@ -732,7 +732,7 @@ class MaskMultiCounter(Statistic):
         self._nodata_mask = None
 
     def measurements(self, input_measurements):
-        nodata = 0xFFFF
+        nodata = -1
         bit_defs = input_measurements[0]['flags_definition']
 
         if self._nodata_flags is not None:
@@ -743,7 +743,7 @@ class MaskMultiCounter(Statistic):
             v['mask'] = create_mask_value(bit_defs, **flags)
 
         return [dict(name=v['name'],
-                     dtype='uint16',
+                     dtype='int16',
                      units='1',
                      nodata=nodata) for v in self._vars]
 
@@ -761,7 +761,7 @@ class MaskMultiCounter(Statistic):
                 return invalid_data_mask
             return None
 
-        nodata = 0xFFFF
+        nodata = -1
         pq = list(ds.data_vars.values())[0]
 
         invalid_data_mask = build_invalid_mask(pq)

--- a/datacube_stats/version.py
+++ b/datacube_stats/version.py
@@ -5,4 +5,4 @@ defined in datacube_stats/__init__.py then install would fail because there are 
 dependencies imported in datacube_stats/__init__.py that are not present until after
 install. Do not import anything into this module."""
 
-__version__ = '0.9a4'
+__version__ = '0.9a5-kk'

--- a/datacube_stats/version.py
+++ b/datacube_stats/version.py
@@ -5,4 +5,4 @@ defined in datacube_stats/__init__.py then install would fail because there are 
 dependencies imported in datacube_stats/__init__.py that are not present until after
 install. Do not import anything into this module."""
 
-__version__ = '0.9a5-kk'
+__version__ = '0.9a4'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup(
     author='Geosience Australia',
     author_email='datacube@ga.gov.au',
     description='Perform statistics operations on a Data Cube',
-    install_requires=['xarray', 'click', 'pandas', 'numpy', 'datacube', 'rasterio', 'pyyaml', 'cloudpickle', 'boltons'],
+    install_requires=['xarray', 'click', 'pandas', 'numpy', 'datacube', 'rasterio', 'pyyaml',
+                      'cloudpickle', 'boltons', 'pydash'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'mock'],
     entry_points={


### PR DESCRIPTION
Adding top level config `var_attributes` which is a dictionary from `variable_name` to a dictionary of attributes.

```yaml
var_attributes:
  clear_observation_count:
    long_name: Number of clear observations for a pixel in a time period
    coverage_content_type: qualityInformation
  total_observation_count:
    long_name: Total observations for a pixel in a time period
    coverage_content_type: qualityInformation
```

Before this change per variable attributes could only be customised from within a plugin code. This is to enable NETCDF:CF compliance.

Also adding defaults to make sure that even un-configured variable will come out CF compliant.


