### PR TITLE
Enhancements to the medoid statistic

### DIFF
--- a/configurations/fc/fc_ls8_2014_seasonal_medoid.yaml
+++ b/configurations/fc/fc_ls8_2014_seasonal_medoid.yaml
@@ -1,0 +1,86 @@
+sources:
+  - product: ls8_fc_albers
+    group_by: solar_day
+    measurements: [BS, PV, NPV, UE]
+    mask_nodata: False
+    masks:
+      - product: ls8_pq_albers
+        measurement: pixelquality
+        group_by: solar_day
+        fuse_func: datacube.helpers.ga_pq_fuser
+        flags:
+          contiguous: True
+          cloud_acca: no_cloud
+          cloud_fmask: no_cloud
+          cloud_shadow_acca: no_cloud_shadow
+          cloud_shadow_fmask: no_cloud_shadow
+          blue_saturated: False
+          green_saturated: False
+          red_saturated: False
+          nir_saturated: False
+          swir1_saturated: False
+          swir2_saturated: False
+
+date_ranges:
+  start_date: 2014-09-01
+  end_date: 2014-12-01
+  stats_duration: 3m
+  step_size: 3m
+
+location: '/g/data/u46/users/ia1511/Work/data/FC/FC-medoid/medoid'
+
+storage:
+  driver: NetCDFCF
+
+  crs: EPSG:3577
+  tile_size:
+          x: 100000.0
+          y: 100000.0
+  resolution:
+          x: 25
+          y: -25
+  chunking:
+      x: 200
+      y: 200
+      time: 1
+  dimension_order: [time, y, x]
+
+global_attributes:
+  title: TODO
+  description: TODO
+  institution: Commonwealth of Australia (Geoscience Australia)
+  keywords_vocabulary: TODO
+  keywords: TODO
+  platform: LANDSAT-5,LANDSAT-7,LANDSAT-8
+  instrument: TM,ETM+,OLI
+  publisher_email: earth.observation@ga.gov.au
+  publisher_name: Section Leader, Operations Section, NEMO, Geoscience Australia
+  publisher_url: http://www.ga.gov.au
+  license: CC BY Attribution 4.0 International License
+  cdm_data_type: Grid
+  product_version: 2
+  product_suite: TODO
+  acknowledgment: Landsat data is provided by the United States Geological Survey (USGS) through direct reception of the data at Geoscience Australias satellite reception facility or download.
+  coverage_content_type: physicalMeasurement
+  cdm_data_type: Grid
+
+## Computational
+# Decide based on how much can fit into memory on the node that is running the job.
+computation:
+  chunking:
+    x: 1000
+    y: 1000
+
+## Define statistics to perform and how to store the data
+output_products:
+ - name: ls8_fc_stats_albers
+   product_type: fractional_cover_statistical_summary
+   statistic: medoid
+   statistic_args:
+       minimum_valid_observations: 3
+       input_measurements: [BS, PV, NPV]
+       output_measurements: [BS, PV, NPV, UE]
+   output_params:
+     zlib: True
+     fletcher32: True
+   file_path_template: 'LS_FC_PC10/{x}_{y}/LS_FC_PC10_3577_{x}_{y}_{epoch_start:%Y%m%d}_{epoch_end:%Y%m%d}.nc'

--- a/datacube_stats/statistics.py
+++ b/datacube_stats/statistics.py
@@ -628,6 +628,136 @@ class MedoidNoProv(PerStatIndexStat):
         super(MedoidNoProv, self).__init__(stat_func=_compute_medoid)
 
 
+class FCMedoid(Statistic):
+    def __init__(self,
+                 minimum_valid_observations=3,
+                 input_measurements=None,
+                 output_measurements=None,
+                 metadata_producers=None):
+
+        # if not enough observations, will fill with no data
+        self.minimum_valid_observations = minimum_valid_observations
+
+        # list of measurements that contribute to medoid calculation
+        self.input_measurements = input_measurements
+
+        # list of reported measurements
+        self.output_measurements = output_measurements
+
+        # attach observation time (in days) if no other metadata requested
+        if metadata_producers is None:
+            self._metadata_producers = [ObservedDaysSince()]
+        else:
+            self._metadata_producers = metadata_producers
+
+    def select_names(self, wanted_names, all_names):
+        """ Only select the measurements names in the wanted list. """
+        if wanted_names is None:
+            # default: include everything
+            return all_names
+
+        invalid = [name
+                   for name in wanted_names
+                   if name not in all_names]
+
+        if invalid:
+            msg = 'Specified measurements not found: {}'
+            raise StatsConfigurationError(msg.format(invalid))
+
+        return wanted_names
+
+    def measurements(self, input_measurements):
+        base = super(FCMedoid, self).measurements(input_measurements)
+
+        selected_names = self.select_names(self.output_measurements,
+                                           [m['name'] for m in base])
+
+        selected = [m for m in base if m['name'] in selected_names]
+
+        extra = [producer.measurement()
+                 for producer in self._metadata_producers]
+
+        return selected + extra
+
+    def medoid_indices(self, arr, invalid):
+        # vectorized version of `argnanmedoid`
+        bands, times, ys, xs = arr.shape
+
+        diff = (arr.reshape(bands, times, 1, ys, xs) -
+                arr.reshape(bands, 1, times, ys, xs))
+
+        dist = np.linalg.norm(diff, axis=0)
+        dist_sum = nansum(dist, axis=0)
+
+        dist_sum[invalid] = np.inf
+        return np.argmin(dist_sum, axis=0)
+
+    def compute(self, data):
+        # calculate medoid using only the fields in `input_measurements`
+        input_data = data[self.select_names(self.input_measurements,
+                                            list(data.data_vars))]
+
+        # calculate medoid indices
+        arr = input_data.to_array().values
+        invalid = anynan(arr, axis=0)
+        index = self.medoid_indices(arr, invalid)
+
+        # pixels for which there is not enough data
+        count_valid = np.count_nonzero(~invalid, axis=0)
+        not_enough = count_valid < self.minimum_valid_observations
+
+        # only report the measurements requested
+        output_data = data[self.select_names(self.output_measurements,
+                                             list(data.data_vars))]
+
+        def section_by_index(array, axis, index):
+            """
+            Take the slice of `var` indexed by entries of `index`
+            along the specified `axis`.
+            """
+            # alternative `axisindex` implementation
+
+            # possible index values for each dimension represented
+            # as numpy arrays all having the shape of `index`
+            indices = np.ix_(*[np.arange(dim) for dim in index.shape])
+
+            # the slice is taken along `axis`
+            # except for the array `index` itself, the other indices
+            # do nothing except trigger `numpy` fancy indexing
+            fancy_index = indices[:axis] + (index,) + indices[axis:]
+
+            # result has the same shape as `index`
+            return array[fancy_index]
+
+        def masked_section(var, axis, nodata):
+            """ Extracts data at `index` for a `var` of type `ndarray`. """
+            result = section_by_index(var, axis, index)
+            result[not_enough] = nodata
+            return result
+
+        def reduction(var):
+            """ Extracts data at `index` for a `var` of type `DataArray`. """
+            return var.reduce(masked_section, dim='time', nodata=var.nodata)
+
+        def attach_metadata(result):
+            """ Attach additional metadata to the `result`. """
+            # used to attach time stamp on the medoid observations
+            for metadata_producer in self._metadata_producers:
+                var_name, var_data = metadata_producer.compute(data, index)
+                nodata = metadata_producer.measurement()['nodata']
+                var_data.data[not_enough] = nodata
+                result[var_name] = var_data
+
+            return result
+
+        return attach_metadata(output_data.apply(reduction,
+                                                 keep_attrs=True))
+
+    def __repr__(self):
+        msg = 'FCMedoid<minimum_valid_observations={}>'
+        return msg.format(self.minimum_valid_observations)
+
+
 class FlagCounter(Statistic):
     """
     Count number of flagged pixels
@@ -795,6 +925,7 @@ STATS = {
     'percentile_no_prov': PercentileNoProv,
     'medoid': Medoid,
     'medoid_no_prov': MedoidNoProv,
+    'fc_medoid': FCMedoid,
     'simple_normalised_difference': NormalisedDifferenceStats,
     # 'ndvi_stats': NormalisedDifferenceStats(name='ndvi', band1='nir', band2='red',
     #                                         stats=['min', 'mean', 'max']),


### PR DESCRIPTION
Currently the enhancements live in a separate class `FCMedoid`.
It may be worthwhile to merge them into the `Medoid` class itself in the
future.

- New medoid has statistics name `fc_medoid`
- Add an optional argument `minimum_valid_observations` for a pixel to
  have for its medoid to be calculated (defaults to 3)
- Add ability to specify `input_measurements` to calculate medoid on
  (defaults to all)
- Add ability to specify `output_measurements` to report (defaults to
  all)
- Vectorize `argnanmedoid` in a method named `medoid_indices` over pixel
  coordinates (may be pulled outside the class if needed)
- Re-implement `axisindex` using `numpy` fancy indexing (rather than
  arithmetic on indices) that currently lives inside the `compute` method as
  an inner function `section_by_index` (may be pulled outside the class
  if needed)