### PR TITLE
Dealing with missing mask data better

### DIFF
--- a/datacube_stats/cli/tile_check.py
+++ b/datacube_stats/cli/tile_check.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import click
+import pickle
+import time
+
+
+def ds_to_key(ds, cell_idx, solar_day):
+    return '{}|{:+03},{:+03}'.format(solar_day, *cell_idx)
+
+
+def flat_map_ds(proc, obs):
+    from datacube_stats.utils import tile_flatten_sources
+    from datacube.api.query import solar_day
+
+    for cell_idx, tile in obs.items():
+        for ds in tile_flatten_sources(tile):
+            yield proc(ds, cell_idx=cell_idx, solar_day=solar_day(ds))
+
+
+def flat_foreach_ds(proc, obs):
+    for _ in flat_map_ds(proc, obs):
+        pass
+
+
+@click.command()
+@click.argument('products', nargs=-1, type=str)
+@click.option('--year', type=int)
+@click.option('--month', type=int)
+@click.option('--save', type=str, nargs=1)
+def main(products, year, month, save):
+    from datacube_stats.utils.query import multi_product_list_cells
+    import datacube
+    from datacube.api import GridWorkflow
+
+    query = {}
+    if year is not None:
+        if month is not None:
+            query['time'] = ('{}-{}-01'.format(year, month),
+                             '{}-{}-01'.format(year, month+1))
+        else:
+            query['time'] = ('{}-01-01'.format(year),
+                             '{}-12-31'.format(year))
+
+    dc = datacube.Datacube(app='dbg')
+    gw = GridWorkflow(product=products[0],
+                      index=dc.index)
+
+    click.echo('## Starting to run query', err=True)
+    t_start = time.time()
+    co_common, co_unmatched = multi_product_list_cells(products, gw, **query)
+    t_took = time.time() - t_start
+    click.echo('## Completed in {} seconds'.format(t_took), err=True)
+
+    if save is not None:
+        click.echo('## Saving data to {}'.format(save), err=True)
+        with open(save, 'wb') as f:
+            pickle.dump(dict(co_common=co_common, co_unmatched=co_unmatched), f)
+            f.close()
+        click.echo(' done')
+
+    click.echo('## Processing results,  ...wait', err=True)
+
+    coverage = set(flat_map_ds(ds_to_key, co_common[0]))
+    um = set(flat_map_ds(ds_to_key, co_unmatched[0]))
+
+    # These tiles have both matched and unmatched data on the same solar day
+    # It's significant cause these are the ones that will interfere with
+    # masking if masking is done the "usual way"
+    um_with_siblings = um - (um - coverage)
+
+    click.echo('## Found {} matched records and {} unmatched'.format(len(coverage), len(um)))
+    click.echo('##   Of {} unmatched records {} are "dangerous" for masking'.
+               format(len(um), len(um_with_siblings)))
+    click.echo('##')
+
+    def dump_unmatched_ds(ds, cell_idx, solar_day):
+        k = ds_to_key(ds, cell_idx, solar_day)
+        flag = '!' if k in coverage else '.'
+        click.echo('{} {} {} {}'.format(k, flag, ds.id, ds.local_path))
+
+    for (idx, product) in enumerate(products):
+        click.echo('## unmatched ###########################')
+        click.echo('## {}'.format(product))
+        click.echo('########################################')
+        flat_foreach_ds(dump_unmatched_ds, co_unmatched[idx])
+
+
+if __name__ == '__main__':
+    main()

--- a/datacube_stats/cli/tile_check.py
+++ b/datacube_stats/cli/tile_check.py
@@ -24,11 +24,11 @@ def flat_foreach_ds(proc, obs):
         pass
 
 
-@click.command()
+@click.command(help='Given two products or more, report tiles present in one but not the other')
 @click.argument('products', nargs=-1, type=str)
-@click.option('--year', type=int)
-@click.option('--month', type=int)
-@click.option('--save', type=str, nargs=1)
+@click.option('--year', type=int, help='Limit processing to a single year')
+@click.option('--month', type=int, help='Limit processing to a single month, need to set year as well')
+@click.option('--save', type=str, nargs=1, help='Dump debug data into pickle file')
 def main(products, year, month, save):
     from datacube_stats.utils.query import multi_product_list_cells
     import datacube

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -651,6 +651,7 @@ class GriddedTaskGenerator(object):
         self.grid_spec = _make_grid_spec(storage)
         self.geopolygon = geopolygon
         self.cell_index = cell_index
+        self._total_unmatched = 0
 
     def __call__(self, index, sources_spec, date_ranges):
         """
@@ -662,6 +663,9 @@ class GriddedTaskGenerator(object):
         :param index: Datacube Index
         :return:
         """
+        from .utils.query import multi_product_list_cells
+        from .utils import report_unmatched_datasets
+
         workflow = GridWorkflow(index, grid_spec=self.grid_spec)
 
         for time_period in date_ranges:
@@ -674,13 +678,22 @@ class GriddedTaskGenerator(object):
             for source_spec in sources_spec:
                 group_by_name = source_spec.get('group_by', DEFAULT_GROUP_BY)
                 source_filter = source_spec.get('source_filter', None)
-                data = workflow.list_cells(product=source_spec['product'], time=time_period,
-                                           group_by=group_by_name, geopolygon=self.geopolygon,
-                                           cell_index=self.cell_index, source_filter=source_filter)
-                masks = [workflow.list_cells(product=mask['product'], time=time_period,
-                                             group_by=group_by_name, geopolygon=self.geopolygon,
-                                             cell_index=self.cell_index)
-                         for mask in source_spec.get('masks', [])]
+
+                all_products = [source_spec['product']] + [m['product'] for m in source_spec.get('masks', [])]
+
+                product_query = {all_products[0]: {'source_filter': source_filter}}
+
+                all_data, unmatched_ = multi_product_list_cells(all_products, workflow,
+                                                                product_query=product_query,
+                                                                cell_index=self.cell_index,
+                                                                time=time_period,
+                                                                group_by=group_by_name,
+                                                                geopolygon=self.geopolygon)
+
+                self._total_unmatched += report_unmatched_datasets(unmatched_[0], lambda s: _LOG.warning(s))
+
+                data = all_data[0]
+                masks = all_data[1:]
 
                 for tile_index, sources in data.items():
                     task = tasks.setdefault(tile_index, StatsTask(time_period=time_period, tile_index=tile_index))
@@ -695,6 +708,11 @@ class GriddedTaskGenerator(object):
                 _LOG.info('Created %s tasks for time period: %s. In: %s', len(tasks), time_period, timer)
             for task in tasks.values():
                 yield task
+
+    def __del__(self):
+        if self._total_unmatched > 0:
+            _LOG.warning('There were source datasets for which masks were not found, total: {}'.
+                         format(self._total_unmatched))
 
 
 def _make_grid_spec(storage):

--- a/datacube_stats/main.py
+++ b/datacube_stats/main.py
@@ -683,17 +683,14 @@ class GriddedTaskGenerator(object):
 
                 product_query = {all_products[0]: {'source_filter': source_filter}}
 
-                all_data, unmatched_ = multi_product_list_cells(all_products, workflow,
-                                                                product_query=product_query,
-                                                                cell_index=self.cell_index,
-                                                                time=time_period,
-                                                                group_by=group_by_name,
-                                                                geopolygon=self.geopolygon)
+                (data, *masks), unmatched_ = multi_product_list_cells(all_products, workflow,
+                                                                      product_query=product_query,
+                                                                      cell_index=self.cell_index,
+                                                                      time=time_period,
+                                                                      group_by=group_by_name,
+                                                                      geopolygon=self.geopolygon)
 
                 self._total_unmatched += report_unmatched_datasets(unmatched_[0], lambda s: _LOG.warning(s))
-
-                data = all_data[0]
-                masks = all_data[1:]
 
                 for tile_index, sources in data.items():
                     task = tasks.setdefault(tile_index, StatsTask(time_period=time_period, tile_index=tile_index))

--- a/datacube_stats/utils/__init__.py
+++ b/datacube_stats/utils/__init__.py
@@ -1,6 +1,7 @@
 """
 Useful utilities used in Stats
 """
+from __future__ import print_function
 import itertools
 
 import numpy as np
@@ -109,3 +110,49 @@ def wofs_fuser(dest, src):
         wofs_mask(src, wet=True) & wofs_mask(dest, dry=True))
     np.copyto(dest, 2, where=invalid)
     return dest
+
+
+def tile_to_list(tile):
+    """
+    Extract tile sources xarray into a list of tuples of datasets
+    """
+    return [a.item() for a in tile.sources]
+
+
+def tile_flatten_sources(tile):
+    """
+    Extract sources from tile as a flat list of Dataset objects,
+    this removes any grouping that might have been applied to tile sources
+    """
+    from functools import reduce
+    return reduce(list.__add__, [list(a.item()) for a in tile.sources])
+
+
+def report_unmatched_datasets(co_unmatched, logger=None):
+    """ Printout in "human" format unmatched datasets
+
+    co_unmatched -- dict (int,int) => Tile
+    logger -- function that logs string, by default will print to stdout
+
+    returns number of datasets that were skipped
+    """
+    def default_logger(s):
+        print(s)
+
+    logger = default_logger if logger is None else logger
+    n = 0
+
+    for cell_idx, tile in co_unmatched.items():
+        dss = tile_flatten_sources(tile)
+
+        if len(dss) == 0:
+            continue
+
+        n += len(dss)
+
+        logger('Skippping files in tile {},{}'.format(*cell_idx))
+
+        for ds in dss:
+            logger(' {} {}'.format(ds.id, ds.local_path))
+
+    return n

--- a/datacube_stats/utils/__init__.py
+++ b/datacube_stats/utils/__init__.py
@@ -150,7 +150,7 @@ def report_unmatched_datasets(co_unmatched, logger=None):
 
         n += len(dss)
 
-        logger('Skippping files in tile {},{}'.format(*cell_idx))
+        logger('Skipping files in tile {},{}'.format(*cell_idx))
 
         for ds in dss:
             logger(' {} {}'.format(ds.id, ds.local_path))

--- a/datacube_stats/utils/query.py
+++ b/datacube_stats/utils/query.py
@@ -73,7 +73,8 @@ def multi_product_list_cells(products, gw, cell_index=None, product_query={}, **
 
         for i in range(len(products)):
             if cidx in obs[i]:
-                co_common[i][cidx] = common[i]
+                if not cell_is_empty(common[i]):
+                    co_common[i][cidx] = common[i]
 
                 if not cell_is_empty(unmatched[i]):
                     co_unmatched[i][cidx] = unmatched[i]

--- a/datacube_stats/utils/query.py
+++ b/datacube_stats/utils/query.py
@@ -1,0 +1,84 @@
+def common_subset(sets, key_by=None):
+    """ From a list of lists compute set common to all lists.
+
+        NOTE: list can also be a lazy i.e. and iterator
+    """
+    def mk_get(key_by):
+        if key_by is None:
+            return lambda x: x if type(x) is set else set(x)
+        else:
+            return lambda xs: set(key_by(x) for x in xs)
+
+    get = mk_get(key_by)
+
+    cc = None
+    for s in sets:
+        if cc is None:
+            cc = get(s)
+        else:
+            missing = cc - get(s)
+            cc = cc - missing
+    return cc
+
+
+def common_obs_per_cell(*tile_obs):
+
+    def ds_time(ds): return ds.center_time
+
+    tt_common = common_subset([o['datasets'] for o in tile_obs], ds_time)
+
+    def pick_with(o, pred):
+        o_ = o.copy()
+        o_['datasets'] = [ds for ds in o['datasets'] if pred(ds)]
+        return o_
+
+    def pick_common(o): return pick_with(o, lambda ds: ds_time(ds) in tt_common)
+
+    def pick_unmatched(o): return pick_with(o, lambda ds: ds_time(ds) not in tt_common)
+
+    return ([pick_common(o) for o in tile_obs],
+            [pick_unmatched(o) for o in tile_obs])
+
+
+def multi_product_list_cells(products, gw, cell_index=None, product_query={}, **query):
+    """
+    products list of product names
+    gw - GridWorkflow
+    product_query -- dict product_name => product specific query
+    """
+    from functools import reduce
+    from datacube.api.query import query_group_by
+    from datacube.api import GridWorkflow
+
+    empty_cell = dict(datasets=[], geobox=None)
+    co_common = [dict() for _ in products]
+    co_unmatched = [dict() for _ in products]
+
+    group_by = query_group_by(**query)
+
+    obs = [gw.cell_observations(product=product,
+                                cell_index=cell_index,
+                                **product_query.get(product, {}),
+                                **query)
+           for product in products]
+
+    # set of all cell indexes found across all products
+    all_cell_idx = set(reduce(list.__add__,
+                              [list(o.keys()) for o in obs]))
+
+    def cell_is_empty(c): return len(c['datasets']) == 0
+
+    for cidx in all_cell_idx:
+        common, unmatched = common_obs_per_cell(*[o.get(cidx, empty_cell) for o in obs])
+
+        for i in range(len(products)):
+            if cidx in obs[i]:
+                co_common[i][cidx] = common[i]
+
+                if not cell_is_empty(unmatched[i]):
+                    co_unmatched[i][cidx] = unmatched[i]
+
+    co_common = [GridWorkflow.group_into_cells(c, group_by=group_by) for c in co_common]
+    co_unmatched = [GridWorkflow.group_into_cells(c, group_by=group_by) for c in co_unmatched]
+
+    return co_common, co_unmatched

--- a/datacube_stats/utils/query.py
+++ b/datacube_stats/utils/query.py
@@ -1,7 +1,9 @@
 def common_subset(sets, key_by=None):
     """ From a list of lists compute set common to all lists.
 
-        NOTE: list can also be a lazy i.e. and iterator
+    sets   -- List or iterator of collections of objects. (Example: [[a,b,c], [b,c,d]])
+    key_by -- Function that extracts/computes key from object, defaults to identity
+
     """
     def mk_get(key_by):
         if key_by is None:
@@ -22,6 +24,14 @@ def common_subset(sets, key_by=None):
 
 
 def common_obs_per_cell(*tile_obs):
+    """Given cell observations for one given tile, from two a more products, split them into two sets:
+
+    - First one contains observations present in all of the products
+    - Second one contains the leftovers
+
+    *tile_obs -- [{'datasets': [Dataset],
+                   'geobox': Geobox}]
+    """
 
     def ds_time(ds): return ds.center_time
 
@@ -41,10 +51,29 @@ def common_obs_per_cell(*tile_obs):
 
 
 def multi_product_list_cells(products, gw, cell_index=None, product_query={}, **query):
-    """
-    products list of product names
-    gw - GridWorkflow
-    product_query -- dict product_name => product specific query
+    """This is similar to GridWorkflow.list_cells but generalised to multiple
+    products. Only datasets that are available in all of the products are
+    reported.
+
+    Datasets that do not have a full set across all products are returned in a
+    separate group.
+
+
+    products      -- list of product names
+    gw            -- Preconfigured GridWorkflow object
+    cell_index    -- Limit search area to a single cell
+    product_query -- Product specific query, dict product_name => product specific query
+    **query       -- Common query parameters across all products
+
+    Returns:
+
+    co_common     -- Cell observation that have full set across products
+    co_unmatched  -- Cell observations where at least one product is missing
+
+    Type of `co_common, co_unmatched` is list of dictionaries of tiles.
+
+    `type(co_common[product_idx:Int][cell_idx:(Int,Int)]) == datacube.api.Tile`
+
     """
     from functools import reduce
     from datacube.api.query import query_group_by

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'console_scripts': [
             'datacube-stats = datacube_stats.main:main',
             'datacube-stats-qsub = datacube_stats.cli.datacube_stats_qsub:qsub',
+            'datacube-tile-check = datacube_stats.cli.tile_check:main'
         ],
         'datacube.stats': [
             'wofs-summary = datacube_stats.statistics:WofsStats'


### PR DESCRIPTION
Sometimes PQ tiles are missing from the index, this interacts badly with
`group_by=solar_day` option, basically missing mask tile in the grouped section
makes non-missing tile unusable because of the way timestamps are computed and
used throughout the datacube systems.

This change introduces `multi_product_list_cells` function that ensures that
only matching set of datasets is computed before `group_by=solar_day` is
applied. We also detect and log source files for which masks were not found.