### PR TITLE
Qsub launcher 2

### DIFF
--- a/datacube_stats/cli/qsub.py
+++ b/datacube_stats/cli/qsub.py
@@ -1,0 +1,215 @@
+import click
+
+NUM_CPUS_PER_NODE = 16
+_l_flags = 'mem ncpus walltime wd'.split(' ')
+
+_pass_thru_keys = 'name project queue env_vars wd noask'.split(' ')
+_valid_keys = _pass_thru_keys + 'walltime nodes mem extra_qsub_args'.split(' ')
+
+
+class QsubLauncher(object):
+    def __init__(self, params):
+        self._params = params
+
+    def dump_options(self):
+        import yaml
+        click.echo(yaml.dump(dict(qsub=self._params)))
+
+    def __call__(self, *args):
+        from .qsub import qsub_self_launch
+        r, output = qsub_self_launch(self._params, *args)
+        click.echo(output)
+        return r
+
+
+class QSubParamType(click.ParamType):
+    name = 'QSUB params'
+
+    def convert(self, value, param, ctx):
+        from .qsub import norm_qsub_params, parse_comma_args
+
+        try:
+            p = parse_comma_args(value, _valid_keys)
+
+            if 'wd' not in p:
+                p['wd'] = True
+
+            p = norm_qsub_params(p)
+            return QsubLauncher(p)
+        except ValueError:
+            self.fail('Failed to parse: {}'.format(value), param, ctx)
+
+
+QSUB = QSubParamType()
+
+with_qsub = click.option('--qsub', type=QSUB,
+                         help='Launch via qsub')
+
+
+def parse_comma_args(s, valid_keys=None):
+    import re
+
+    def parse_one(a):
+        kv = tuple(s.strip() for s in re.split(' *[=:] *', a))
+        if len(kv) == 1:
+            kv = (kv[0], True)
+
+        if len(kv) != 2:
+            raise ValueError('Bad option: ' + a)
+
+        if valid_keys:
+            k = kv[0]
+            if k not in valid_keys:
+                raise ValueError('Unexpected key:'+k)
+
+        return kv
+
+    return dict(parse_one(a) for a in re.split('[,;\n]', s) if a != '')
+
+
+def normalise_walltime(x):
+    import re
+
+    if x is None or x.find(':') >= 0:
+        return x
+
+    m = re.match('^([0-9]+) *([hms]|min|minutes|hours)?$', x)
+    if m is None:
+        return None
+
+    aliases = {'hours': 'h',
+               None: 'h',
+               'min': 'm',
+               'minutes': 'm'}
+
+    scale = dict(h=60*60,
+                 m=60,
+                 s=1)
+
+    def fmt(secs):
+        h = secs//(60*60)
+        m = (secs//60) % 60
+        s = secs % 60
+        return '{}:{:02}:{:02}'.format(h, m, s)
+
+    v, units = m.groups()
+    units = aliases.get(units, units)
+    return fmt(int(v)*scale[units])
+
+
+def normalise_mem(x):
+    import re
+
+    named = dict(small=2,
+                 medium=4,
+                 large=7.875)
+
+    if x in named:
+        return named[x]
+
+    m = re.match('^ *([0-9]+) *([g|G][bB]*)* *$', x)
+    if m is None:
+        return None
+    return int(m.groups()[0])
+
+
+def norm_qsub_params(p):
+    from pydash import pick
+
+    nodes = int(p.get('nodes', 1))
+    ncpus = nodes*NUM_CPUS_PER_NODE
+
+    mem = normalise_mem(p.get('mem', 'small'))
+    mem = int((mem*NUM_CPUS_PER_NODE*1024 - 512)*nodes)
+    mem = '{}MB'.format(mem)
+
+    walltime = normalise_walltime(p.get('walltime'))
+
+    extra_qsub_args = p.get('extra_qsub_args', [])
+    if type(extra_qsub_args) == str:
+        extra_qsub_args = extra_qsub_args.split(' ')
+
+    pp = dict(ncpus=ncpus,
+              mem=mem,
+              walltime=walltime,
+              extra_qsub_args=extra_qsub_args)
+
+    pp.update(pick(p, _pass_thru_keys))
+
+    return pp
+
+
+def build_qsub_args(**p):
+    args = []
+
+    flags = dict(project='-P',
+                 queue='-q',
+                 name='-N')
+
+    def add_l_arg(n):
+        v = p.get(n)
+        if v is not None:
+            if type(v) is bool:
+                if v:
+                    args.append('-l{}'.format(n))
+            else:
+                args.append('-l{}={}'.format(n, v))
+
+    def add_arg(n):
+        v = p.get(n)
+        if v is not None:
+            flag = flags[n]
+            args.extend([flag, v])
+
+    for n in _l_flags:
+        add_l_arg(n)
+
+    for n in flags.keys():
+        add_arg(n)
+
+    args.extend(p.get('extra_qsub_args', []))
+
+    # TODO: deal with env_vars!
+
+    return args
+
+
+def self_launch_args(*args):
+    """
+    Build tuple in the form (current_python, current_script, *args)
+    """
+    import sys
+    from pathlib import Path
+
+    py_file = str(Path(sys.argv[0]).absolute())
+    return (sys.executable, py_file) + args
+
+
+def generate_self_launch_script(*args):
+    from ..utils import pbs
+    s = "#!/bin/bash\n\n"
+    s += pbs.generate_env_header()
+    s += '\n\nexec ' + ' '.join("'{}'".format(s) for s in self_launch_args(*args))
+    return s
+
+
+def qsub_self_launch(qsub_opts, *args):
+    from subprocess import Popen, PIPE
+
+    script = generate_self_launch_script(*args)
+    qsub_args = build_qsub_args(**qsub_opts)
+
+    noask = qsub_opts.get('noask', False)
+
+    if not noask:
+        confirmed = click.confirm('Submit to pbs?')
+        if not confirmed:
+            return (0, 'Aborted by user')
+
+    proc = Popen(['qsub'] + qsub_args, stdin=PIPE, stdout=PIPE)
+    proc.stdin.write(script.encode('utf-8'))
+    proc.stdin.close()
+    out_txt = proc.stdout.read().decode('utf-8')
+    exit_code = proc.wait()
+
+    return exit_code, out_txt

--- a/datacube_stats/cli/qsub.py
+++ b/datacube_stats/cli/qsub.py
@@ -202,6 +202,7 @@ def qsub_self_launch(qsub_opts, *args):
     noask = qsub_opts.get('noask', False)
 
     if not noask:
+        click.echo('Args: ' + ' '.join(args))
         confirmed = click.confirm('Submit to pbs?')
         if not confirmed:
             return (0, 'Aborted by user')

--- a/datacube_stats/cli/qsub_test.py
+++ b/datacube_stats/cli/qsub_test.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import click
+from .qsub import with_qsub
+
+
+@click.command(help='TODO')
+@click.argument('products', nargs=-1, type=str)
+@with_qsub
+@click.option('--pbs-celery', is_flag=True, help='Launch worker pool when running on PBS')
+def main(products, qsub=None, pbs_celery=False):
+    import datacube
+    import datacube_stats
+    import pathlib
+    from ..utils import pbs
+
+    if qsub:
+        qsub.dump_options()
+        return qsub('--pbs-celery', *products)
+
+    qsize = 100
+
+    if pbs.is_under_pbs():
+        qsize = pbs.preferred_queue_size()
+
+    click.echo(datacube.__file__)
+    click.echo(datacube_stats.__file__)
+    click.echo('PWD:' + str(pathlib.Path('.').absolute()))
+    click.echo('celery_flag:{}'.format('Y' if pbs_celery else 'N'))
+    click.echo('queue size: {}'.format(qsize))
+    click.echo('  > ' + ' '.join(products))
+
+    return 0
+
+
+if __name__ == '__main__':
+    main()

--- a/datacube_stats/cli/qsub_test.py
+++ b/datacube_stats/cli/qsub_test.py
@@ -2,35 +2,127 @@
 from __future__ import print_function
 
 import click
+from collections import namedtuple
+import pathlib
+
+import datacube
+import datacube_stats
+from datacube.executor import SerialExecutor, _get_concurrent_executor
+from datacube.ui.task_app import run_tasks, wrap_task
+
 from .qsub import with_qsub
+from ..utils.pbs import _hostname
+from ..utils import pbs
+
+Task = namedtuple('Task', 'val'.split(' '))
+Result = namedtuple('Result', 'result val op worker'.split(' '))
+
+
+def random_sleep(amount_secs=0.1, prop=0.5):
+    """emulate processing time variance"""
+    from time import sleep
+    from random import uniform
+
+    if uniform(0, 1) < prop:
+        sleep(amount_secs)
+
+
+def task_generator(num_tasks):
+    for i in range(num_tasks):
+        click.echo('Generating task: {}'.format(i))
+        yield Task(i)._asdict()
+
+
+def run_task(task, op):
+    """ Runs across multiple cpus/nodes
+    """
+    from math import sqrt
+
+    if type(task) != Task:
+        task = Task(**task)
+
+    host = _hostname()
+
+    ops = {'sqrt': sqrt,
+           'pow2': lambda x: x*x}
+
+    random_sleep(1, 0.1)  # Sleep for 1 second 10% of the time
+
+    val = task.val
+
+    if val == 666:
+        click.echo('Injecting failure')
+        raise IOError('Fake IO Error')
+
+    result = ops[op](val)
+    click.echo('{} => {}'.format(val, result))
+
+    return Result(result=result,
+                  val=val,
+                  op=op,
+                  worker=host)
+
+
+def log_completed_task(result):
+    click.echo('From [{worker}]: {val} => {op} => {result}'.format(**result._asdict()))
 
 
 @click.command(help='TODO')
-@click.argument('products', nargs=-1, type=str)
+@click.argument('app_config', nargs=1, type=str)
+@click.option('--op', help='Configure dummy task: sqrt|pow2', default='sqrt')
 @with_qsub
+@click.option('--parallel', type=int, help='Run in parallel on local machine')
 @click.option('--pbs-celery', is_flag=True, help='Launch worker pool when running on PBS')
-def main(products, qsub=None, pbs_celery=False):
-    import datacube
-    import datacube_stats
-    import pathlib
-    from ..utils import pbs
-
+def main(app_config, op, qsub=None, parallel=None, pbs_celery=False):
     if qsub:
         qsub.dump_options()
-        return qsub('--pbs-celery', *products)
+        return qsub('--pbs-celery',
+                    '--op', op,
+                    app_config)
 
+    shutdown = None
+    executor = None
     qsize = 100
 
     if pbs.is_under_pbs():
         qsize = pbs.preferred_queue_size()
 
+    try:
+        num_tasks = int(app_config)
+    except ValueError:
+        num_tasks = qsize*10
+
+    if pbs_celery:
+        click.echo('Launching Redis worker pool')
+        try:
+            executor, shutdown = pbs.launch_redis_worker_pool()
+        except RuntimeError:
+            raise click.ClickException('Failed to launch redis worker pool')
+    elif parallel is not None:
+        executor = _get_concurrent_executor(parallel, use_cloud_pickle=True)
+    else:
+        executor = SerialExecutor()
+
     click.echo(datacube.__file__)
     click.echo(datacube_stats.__file__)
     click.echo('PWD:' + str(pathlib.Path('.').absolute()))
-    click.echo('celery_flag:{}'.format('Y' if pbs_celery else 'N'))
+    click.echo('celery_flag: {}'.format('Y' if pbs_celery else 'N'))
     click.echo('queue size: {}'.format(qsize))
-    click.echo('  > ' + ' '.join(products))
+    click.echo('cfg: ' + app_config)
 
+    do_task = wrap_task(run_task, op)
+
+    run_tasks(task_generator(num_tasks),
+              executor,
+              do_task,
+              log_completed_task,
+              qsize)
+
+    if shutdown is not None:
+        click.echo('Calling shutdown hook')
+        shutdown()
+
+    click.echo('All done!')
     return 0
 
 

--- a/datacube_stats/models.py
+++ b/datacube_stats/models.py
@@ -48,6 +48,9 @@ class StatsTask(object):
     def __getitem__(self, item):
         return getattr(self, item)
 
+    def get(self, item, default=None):
+        return getattr(self, item, default)
+
     def __str__(self):
         return "StatsTask(time_period={}, tile_index={})".format(self.time_period, self.tile_index)
 

--- a/datacube_stats/runner.py
+++ b/datacube_stats/runner.py
@@ -1,13 +1,12 @@
 """
 This module is based on the main() method code from FC/NDVI/ingest for running
-tasks using `task_app` and extracts it into a reusable function called `run_taks`.
+tasks using `task_app` and extracts it into a reusable function called `run_task`.
 
 Hopefully this can be pushed back into `task_app` to reduce duplication, and allow
 any bugs or improvements to be fixed in only one place.
 """
 from __future__ import absolute_import, print_function
 
-import click
 import itertools
 
 import logging

--- a/datacube_stats/statistics.py
+++ b/datacube_stats/statistics.py
@@ -760,7 +760,9 @@ class Medoid(Statistic):
                 result[not_enough] = nodata
                 return result
 
-            return var.reduce(worker, dim='time', nodata=var.nodata)
+            from numpy import nan
+            nodata = getattr(var, 'nodata', nan)
+            return var.reduce(worker, dim='time', nodata=nodata)
 
         def attach_metadata(result):
             """ Attach additional metadata to the `result`. """

--- a/datacube_stats/utils/pbs.py
+++ b/datacube_stats/utils/pbs.py
@@ -67,7 +67,7 @@ def get_env(extras=[], **more_env):
     import re
 
     pass_envs = set(['PATH', 'LANG', 'LD_LIBRARY_PATH', 'HOME', 'USER'])
-    REGEXES = ['^PYTHON.*', '^GDAL.*', '^LC.*']
+    REGEXES = ['^PYTHON.*', '^GDAL.*', '^LC.*', '^DATACUBE.*']
     rgxs = [re.compile(r) for r in REGEXES]
 
     def need_this_env(k):

--- a/datacube_stats/utils/pbs.py
+++ b/datacube_stats/utils/pbs.py
@@ -51,6 +51,17 @@ def nodes():
     return _nodes
 
 
+def total_cores():
+    total = 0
+    for n in nodes():
+        total += n.num_cores
+    return total
+
+
+def preferred_queue_size():
+    return total_cores()*2
+
+
 def get_env(extras=[], **more_env):
     import os
     import re

--- a/datacube_stats/utils/pbs.py
+++ b/datacube_stats/utils/pbs.py
@@ -5,8 +5,8 @@ _nodes = None
 
 
 def _hostname():
-    import os
-    return os.environ.get('HOSTNAME', os.environ.get('HOST', 'localhost'))
+    import platform
+    return platform.node()
 
 
 def is_under_pbs():
@@ -127,6 +127,8 @@ def launch_redis_worker_pool(port=6379):
 
     redis_shutdown = cr.launch_redis(redis_port, redis_password)
 
+    print('Launched redis at {}:{}'.format(redis_host, redis_port))
+
     if not redis_shutdown:
         raise RuntimeError('Failed to launch Redis')
 
@@ -154,10 +156,14 @@ def launch_redis_worker_pool(port=6379):
 
     def shutdown():
         cr.app.control.shutdown()
-        redis_shutdown()
+
+        print('Waiting for workers to quit')
 
         # TODO: time limit followed by kill
         for p in worker_procs:
             p.wait()
+
+        print('Shutting down redis-server')
+        redis_shutdown()
 
     return executor, shutdown

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'console_scripts': [
             'datacube-stats = datacube_stats.main:main',
             'datacube-stats-qsub = datacube_stats.cli.datacube_stats_qsub:qsub',
-            'datacube-tile-check = datacube_stats.cli.tile_check:main'
+            'datacube-tile-check = datacube_stats.cli.tile_check:main',
+            'dc-qsub-test = datacube_stats.cli.qsub_test:main',
         ],
         'datacube.stats': [
             'wofs-summary = datacube_stats.statistics:WofsStats'


### PR DESCRIPTION
## Introduction

Main goal is to simplify user experience as far as launching jobs on PBS systems go, particularly when working with customised environments. The idea is to remove the need for creating and passing environment setup scripts. Currently we rely on bash scripts for launching worker pool when running under PBS, there is also a helper python tool `datacube-stats-qsub` for submitting these scripts via `qsub`, user can customise environment setup by supplying a bash script that gets sourced on every node before launching workers. This works fine when no environment customisation is needed, but with custom environment things usually don't work first time. Also current approach forces the use of `dask.distributed` as scheduler, and we know that `dask` tasks are supposed to be idempotent, and our tasks are not, since they generate files as a side-effect of computation.

This pull request moves worker pool launching to python, while still leaving the option to connect to externally managed worker pool. Currently launching for `Celery` based worker pool is supported, but it should be trivial to add support for `dask.distributed` also. Moving worker pool management into python has a number advantages

- Easier to extend and change behaviour (e.g. Redis server password generation and distribution to workers)
- Complex auto-configuration is more feasible in python than in bash
- Easier to debug problems (`qsub -I`, then step through in a debugger)   

## Code UI changes

`Executor` class is no longer exposed, instead there is `TaskRunner` that knows how to

- `start` -- launch worker pool or connect to existing or do nothing 
- `parallel_do` -- run lazy list of tasks through processing function in parallell
- `stop` -- terminate worker pool if it was launched

`queue_size` is now auto-chosen according to underlying parallelism strategy, but can be overwritten on a command line also.

Instead of `@ui.executor_cli_options` there is now `@with_qsub_runner()`, this will populate parameters `runner` and `qsub`, where `runner` is a replacement for `executor`, `queue_size` and bash launcher scripts, and `qsub` performs script self-submission to PBS.

## Command line UI changes 

Adding new command line options to `datacube-stats` instead of `--executor type param` 

```
  --queue-size INTEGER     Overwrite defaults for queue size
  --celery HOST:PORT       Use celery backend for parallel computation. Supply
                           redis server address, or "pbs-launch" to launch
                           redis server and workers when running under pbs.
  --dask HOST:PORT         Use dask.distributed backend for parallel
                           computation. Supply address of dask scheduler.
  --parallel INTEGER       Run locally in parallel
```

Adding `--qsub opts` option that submits a qsub job. 

```
  --qsub OPTS              Launch via qsub, supply comma or new-line separated
                           list of parameters. Try --qsub=help.
```

If you run `datacube-stats --qsub=help`

```
Following parameters are understood:

   nodes    = <int> number of nodes
   walltime = <duration> e.g. "10m" -- ten minutes, "5h" -- five hours
   mem      = (small|medium|high) or 2G, 4G memory per core
   name     = job name
   project  = (u46|v10 etc.)
   queue    = (normal|express)
   noask do not ask for confirmation

Put one pameter per line or use commas to separate parameters.

Examples:
   --qsub 'nodes=10,walltime=3h,project=v10'
   --qsub 'name = my-task
   nodes = 7
   mem = medium
   walltime = 30m
   noask'
```

Job submission looks something like this:

```
datacube-stats --tile-index -5 -32 --output-location . --year 2013 fc_stats.yaml --qsub nodes=1,walltime=5m,name=fc.kk,queue=express
qsub:
  extra_qsub_args: []
  mem: 32256MB
  name: fc.kk
  ncpus: 16
  queue: express
  walltime: 0:05:00
  wd: true

Args: --celery pbs-launch --tile-index -5 -32 --output-location . --year 2013 fc_stats.yaml
Submit to pbs? [y/N]: 
```

