### PR TITLE
Remove unused parameters to `ArbitraryTileMaker`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
   - conda create -n datacube datacube pytest mock boltons pytest-cov coveralls hypothesis shapely
   - source activate datacube
-  - pip install pydash boltons pylint yamllint pytest-cov pep8 voluptuous hdmedians fiona
+  - pip install pydash boltons pylint yamllint pytest-cov pycodestyle voluptuous hdmedians fiona
   - pip install . --no-deps --upgrade
 
   - pip freeze

--- a/check-code.sh
+++ b/check-code.sh
@@ -4,7 +4,7 @@
 set -eu
 set -x
 
-pep8 datacube_stats scripts tests --max-line-length=120
+pycodestyle datacube_stats scripts tests --max-line-length=120
 
 pylint -j 2 --reports no datacube_stats
 

--- a/datacube_stats/tasks.py
+++ b/datacube_stats/tasks.py
@@ -260,10 +260,8 @@ class NonGriddedTaskGenerator(object):
                 group_by_name = source_spec.get('group_by', DEFAULT_GROUP_BY)
 
                 # Build Tile
-                data = make_tile(product=source_spec['product'], time=ep_range,
-                                 group_by=group_by_name, geopoly=self.geopolygon)
-                masks = [make_tile(product=mask['product'], time=ep_range,
-                                   group_by=group_by_name, geopoly=self.geopolygon)
+                data = make_tile(product=source_spec['product'], time=ep_range, group_by=group_by_name)
+                masks = [make_tile(product=mask['product'], time=ep_range, group_by=group_by_name)
                          for mask in source_spec.get('masks', [])]
 
                 if len(data.sources.time) == 0:
@@ -298,8 +296,7 @@ class ArbitraryTileMaker(object):
         self.input_region = input_region
         self.storage = storage
 
-    def __call__(self, product, time, group_by, filter_time=None, geopoly=None,
-                 sources_spec=None, date_ranges=None):
+    def __call__(self, product, time, group_by):
         # Do for a specific poly whose boundary is known
         output_crs = CRS(self.storage['crs'])
         filtered_item = ['geopolygon', 'lon', 'lat', 'longitude', 'latitude', 'x', 'y']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ def is_wet(data):
 def is_clear(data):
     return is_wet(data) | is_dry(data)
 
+
 wofs_arrays = arrays(np.uint8, (1,), elements=integers(0, 255))
 
 


### PR DESCRIPTION
An `ArbitraryTileMaker` object is never called
with these parameters whose default values are set
to `None` and they are never used within the body of
`ArbitraryTileMaker.__call__`. The `geopoly` parameter
passed is identical to the one already stored in
`ArbitraryTileMaker.input_region`.